### PR TITLE
Add Quality Option for Executable

### DIFF
--- a/src/bin/epeg_main.c
+++ b/src/bin/epeg_main.c
@@ -109,7 +109,7 @@ main(int argc, char **argv)
 
    if (!input_file || !output_file) usage(argv[0]);
 
-   if (!thumb_comment) thumb_comment = "Smelly pants!";
+   if (!thumb_comment) thumb_comment = "";
 
    im = epeg_file_open(input_file);
    if (!im) {


### PR DESCRIPTION
src/bin/epeg_main.c set the quality to 80 by default. I have added an option to set the quality.
