### PR TITLE
Memory jpeg output fix

### DIFF
--- a/src/lib/epeg_main.c
+++ b/src/lib/epeg_main.c
@@ -1317,6 +1317,7 @@ _jpeg_empty_output_buffer(j_compress_ptr cinfo)
    p = realloc(*(dst_mgr->im->out.mem.data), *(dst_mgr->im->out.mem.size));
    if (p)
      {
+	*(dst_mgr->im->out.mem.data) = p;
 	memcpy(p + psize, dst_mgr->buf, 65536);
 	dst_mgr->dst_mgr.free_in_buffer = 65536;
 	dst_mgr->dst_mgr.next_output_byte = (JOCTET *)dst_mgr->buf;


### PR DESCRIPTION
Howdy!
I had a bit of trouble using your excellent epeg library with memory based files. After a bit of digging, I found the attached bug (and fix).
Perhaps others would find this useful too.
Thanks,
Peter
