### PR TITLE
Fix for leak of memory when writing EXIF data

### DIFF
--- a/src/lib/epeg_main.c
+++ b/src/lib/epeg_main.c
@@ -1253,6 +1253,7 @@ _epeg_encode(Epeg_Image *im)
    exif_data_save_data(exif, &exif_data, &exif_data_len);
    jpeg_write_marker(&(im->out.jinfo), JPEG_APP0 + 1, exif_data, exif_data_len);
    exif_data_unref(exif);
+   free(exif_data);
 
    /* Output comment if there is one */
    if (im->out.comment && *im->out.comment)

--- a/src/lib/epeg_main.c
+++ b/src/lib/epeg_main.c
@@ -1248,7 +1248,7 @@ _epeg_encode(Epeg_Image *im)
         exif_entry_unref(entry);
    }
    /* Write Exif data to output jpeg file */
-   unsigned char *exif_data;
+   unsigned char *exif_data = NULL;
    unsigned int exif_data_len;
    exif_data_save_data(exif, &exif_data, &exif_data_len);
    jpeg_write_marker(&(im->out.jinfo), JPEG_APP0 + 1, exif_data, exif_data_len);


### PR DESCRIPTION
Fix for leak of memory from writing EXIF data (I noticed that there was a recent commit that fixes a leak when reading, this is unrelated).

To reproduce, run valgrind on a simple executable that resizes a file with an EXIF Orientation entry.

You will end up with a trace that looks somewhat like this:

<pre>
==24917== 126 bytes in 1 blocks are definitely lost in loss record 1 of 8
==24917==    at 0x4C2DD9F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24917==    by 0x51638A: exif_mem_realloc_func (exif-mem.c:23)
==24917==    by 0x5162F3: exif_mem_realloc (exif-mem.c:91)
==24917==    by 0x507265: exif_data_save_data_content (exif-data.c:560)
==24917==    by 0x507549: exif_data_save_data_content (exif-data.c:609)
==24917==    by 0x506F88: exif_data_save_data (exif-data.c:984)
==24917==    by 0x482B7B: _epeg_encode (epeg_main.c:1253)
==24917==    by 0x4826C7: epeg_encode (epeg_main.c:727)
</pre>
