### PR TITLE
Fix XMP rotation bug

### DIFF
--- a/src/lib/epeg_main.c
+++ b/src/lib/epeg_main.c
@@ -834,7 +834,10 @@ _epeg_open_header(Epeg_Image *im)
 
    im->color_space = ((im->in.color_space = im->in.jinfo.out_color_space) == JCS_GRAYSCALE) ? EPEG_GRAY8 : EPEG_RGB8;
    if (im->in.color_space == JCS_CMYK) im->color_space = EPEG_CMYK;
-   
+
+   /* Will be set if orientation is present in EXIF data */
+   im->in.orientation = 0;
+
    for (m = im->in.jinfo.marker_list; m; m = m->next)
      {
 	if (m->marker == JPEG_COM)
@@ -886,7 +889,6 @@ _epeg_open_header(Epeg_Image *im)
 	    *	store it in im->in.orientation. Later, this will
 	    *	be written to the output jpeg Exif data.
 	    */
-            im->in.orientation = 0;
             ExifData *ed = exif_data_new_from_data(m->data, m->data_length);
             if (ed) {
              	exif_byte_order = exif_data_get_byte_order(ed);


### PR DESCRIPTION
This commit addresses the bug #18 with the rotation in the output image.
When both EXIF and XMP data is available in the header data, the
orientation set from the EXIF data will be written over once the XMP
header is read.
This makes sure that the orientation from the EXIF is preserved.